### PR TITLE
WIP: BTHome v2 encryption

### DIFF
--- a/components/bthome_ble_receiver/bthome_ble_receiver_hub.cpp
+++ b/components/bthome_ble_receiver/bthome_ble_receiver_hub.cpp
@@ -8,6 +8,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/components/bthome_base/bthome_parser.h"
+#include "mbedtls/ccm.h"
 
 #include "bthome_ble_receiver_hub.h"
 
@@ -60,8 +61,11 @@ namespace esphome
       // Check and match the device
       const mac_address_t address = device.address_uint64();
 
+      // Get BTHome device configuration (reused for encryption key lookup)
+      auto *btdevice = get_device_by_address(address);
+
       // Parse the payload data
-      const std::vector<uint8_t> &message = service_data.data;
+      std::vector<uint8_t> message = service_data.data;
       const uint8_t *payload_data = message.data();
       auto payload_length = message.size();
 
@@ -72,7 +76,7 @@ namespace esphome
       else if (proto == bthome_base::BTProtoVersion_BTHomeV2)
       {
         uint8_t adv_info = payload_data[0];
-        // bool encryption = bool(adv_info & (1 << 0));       // bit 0
+        bool encryption = bool(adv_info & (1 << 0));       // bit 0
         bool mac_included = bool(adv_info & (1 << 1)); // bit 1
         // bool sleepy_device = bool(adv_info & (1 << 2));    // bit 2
         uint8_t sw_version = (adv_info >> 5) & 7; // 3 bits (5-7);
@@ -81,6 +85,34 @@ namespace esphome
         {
           ESP_LOGD(TAG, "BTHome V2 device is using an unsupported sw_version %d.", sw_version);
           return false;
+        }
+
+        if (encryption)
+        {
+          ESP_LOGD(TAG, "BTHome V2 device is using encryption.");
+
+          // Check if encryption key is configured for this device
+          const uint8_t *encryption_key = nullptr;
+
+          if (btdevice && btdevice->has_encryption_key())
+          {
+            encryption_key = btdevice->get_encryption_key();
+            ESP_LOGD(TAG, "Using configured encryption key for device.");
+          }
+          else
+          {
+            ESP_LOGW(TAG, "BTHome V2 device is using encryption but no encryption_key is configured for this device. Decryption will fail.");
+            return false;
+          }
+
+          if (!decrypt_message_payload_(message, encryption_key, address))
+          {
+            ESP_LOGD(TAG, "BTHome V2 device is using encryption but failed to decrypt the payload.");
+            return false;
+          }
+
+          payload_data = message.data();
+          payload_length = message.size();
         }
 
         if (mac_included)
@@ -96,6 +128,7 @@ namespace esphome
           payload_data += 1;
           payload_length -= 1;
         }
+
       }
 
       // parse the payload and report measurements in the callback
@@ -103,6 +136,93 @@ namespace esphome
 
       return true; // TODO change parse_message_bthome_ to return bool
     }
+
+    bool BTHomeBLEReceiverHub::decrypt_message_payload_(std::vector<uint8_t> &raw, const uint8_t *bindkey, const uint64_t &address) {
+      if (!((raw.size() >= 22) && (raw.size() <= 24))) {
+        ESP_LOGVV(TAG, "decrypt_bthome_payload(): data packet has wrong size (%d)!", raw.size());
+        ESP_LOGVV(TAG, "  Packet : %s", format_hex_pretty(raw.data(), raw.size()).c_str());
+        return false;
+      }
+
+      uint8_t mac_address[6] = {0};
+      mac_address[0] = (uint8_t) (address >> 40);
+      mac_address[1] = (uint8_t) (address >> 32);
+      mac_address[2] = (uint8_t) (address >> 24);
+      mac_address[3] = (uint8_t) (address >> 16);
+      mac_address[4] = (uint8_t) (address >> 8);
+      mac_address[5] = (uint8_t) (address >> 0);
+
+      BTHomeAESVector vector{.key = {0},
+                             .plaintext = {0},
+                             .ciphertext = {0},
+                             .authdata = {0},
+                             .iv = {0},
+                             .tag = {0},
+                             .keysize = 16,
+                             .authsize = 0,
+                             .datasize = 0,
+                             .tagsize = 4,
+                             .ivsize = 13};
+
+      vector.datasize = raw.size() - 9;
+      int cipher_pos = 1;
+
+      const uint8_t *v = raw.data();
+
+      memcpy(vector.key, bindkey, vector.keysize);
+      memcpy(vector.ciphertext, v + cipher_pos, vector.datasize);
+      memcpy(vector.tag, v + raw.size() - vector.tagsize, vector.tagsize);
+      memcpy(vector.iv, mac_address, 6);             // MAC address
+      vector.iv[6] = 0xd2;
+      vector.iv[7] = 0xfc;
+      memcpy(vector.iv + 8, v, 1);                   // device data byte
+      memcpy(vector.iv + 9, v + raw.size() - 8, 4);  // counter
+
+      mbedtls_ccm_context ctx;
+      mbedtls_ccm_init(&ctx);
+
+      int ret = mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, vector.key, vector.keysize * 8);
+      if (ret) {
+        ESP_LOGVV(TAG, "decrypt_bthome_payload(): mbedtls_ccm_setkey() failed.");
+        mbedtls_ccm_free(&ctx);
+        return false;
+      }
+
+      ret = mbedtls_ccm_auth_decrypt(&ctx, vector.datasize, vector.iv, vector.ivsize, vector.authdata, vector.authsize,
+                                     vector.ciphertext, vector.plaintext, vector.tag, vector.tagsize);
+      if (ret) {
+        ESP_LOGVV(TAG, "decrypt_bthome_payload(): authenticated decryption failed.");
+        ESP_LOGVV(TAG, "  Error       : %d", ret);
+        ESP_LOGVV(TAG, "  MAC address : %s", format_hex_pretty(mac_address, 6).c_str());
+        ESP_LOGVV(TAG, "       Packet : %s", format_hex_pretty(raw.data(), raw.size()).c_str());
+        ESP_LOGVV(TAG, "          Key : %s", format_hex_pretty(vector.key, vector.keysize).c_str());
+        ESP_LOGVV(TAG, "           Iv : %s", format_hex_pretty(vector.iv, vector.ivsize).c_str());
+        ESP_LOGVV(TAG, "       Cipher : %s", format_hex_pretty(vector.ciphertext, vector.datasize).c_str());
+        ESP_LOGVV(TAG, "          Tag : %s", format_hex_pretty(vector.tag, vector.tagsize).c_str());
+        mbedtls_ccm_free(&ctx);
+        return false;
+      }
+
+      // replace encrypted payload with plaintext
+      uint8_t *p = vector.plaintext;
+      for (std::vector<uint8_t>::iterator it = raw.begin() + cipher_pos; it != raw.begin() + cipher_pos + vector.datasize;
+           ++it) {
+        *it = *(p++);
+      }
+
+      // clear encrypted flag
+      raw[0] &= ~0x08;
+
+      // remove tag from the end of the payload
+      raw.resize(raw.size() - 8);
+
+      ESP_LOGVV(TAG, "decrypt_bthome_payload(): authenticated decryption passed.");
+      ESP_LOGVV(TAG, "  Plaintext : %s", format_hex_pretty(raw.data(), raw.size()).c_str());
+
+      mbedtls_ccm_free(&ctx);
+      return true;
+    }
+
   }
 }
 

--- a/components/bthome_ble_receiver/bthome_ble_receiver_hub.h
+++ b/components/bthome_ble_receiver/bthome_ble_receiver_hub.h
@@ -29,9 +29,24 @@ namespace esphome
     protected:
       bthome_base::BTProtoVersion_e parse_header_(const esp32_ble_tracker::ServiceData &service_data);
       bool parse_message_payload_(const esp32_ble_tracker::ServiceData &service_data, const esp32_ble_tracker::ESPBTDevice &device, bthome_base::BTProtoVersion_e proto);
+      bool decrypt_message_payload_(std::vector<uint8_t> &raw, const uint8_t *bindkey, const uint64_t &address);
     };
 
   }
 }
+
+struct BTHomeAESVector {
+  uint8_t key[16];
+  uint8_t plaintext[16];
+  uint8_t ciphertext[16];
+  uint8_t authdata[16];
+  uint8_t iv[16];
+  uint8_t tag[16];
+  size_t keysize;
+  size_t authsize;
+  size_t datasize;
+  size_t tagsize;
+  size_t ivsize;
+};
 
 #endif

--- a/components/bthome_receiver_base/bthome_receiver_base_device.cpp
+++ b/components/bthome_receiver_base/bthome_receiver_base_device.cpp
@@ -4,6 +4,7 @@
  Author: Attila Farago
  */
 
+#include <cstring>
 #include "esphome/components/bthome_base/bthome_base_common.h"
 
 #include "bthome_receiver_base_device.h"
@@ -17,10 +18,27 @@ namespace esphome
     using namespace bthome_base;
     static const char *const TAG = "bthome_receiver_base.device";
 
+    void BTHomeReceiverBaseDevice::set_encryption_key(const uint8_t *key)
+    {
+      if (key != nullptr)
+      {
+        memcpy(encryption_key_, key, 16);
+        encryption_key_set_ = true;
+      }
+      else
+      {
+        encryption_key_set_ = false;
+      }
+    }
+
     void BTHomeReceiverBaseDevice::dump_config()
     {
       ESP_LOGCONFIG(TAG, "device %s at 0x%llX", this->name_prefix_.c_str(), this->address_);
       ESP_LOGCONFIG(TAG, "  dump_option %d", this->dump_option_);
+      if (encryption_key_set_)
+      {
+        ESP_LOGCONFIG(TAG, "  encryption_key: set");
+      }
       for (auto sensor : my_sensors)
       {
         ESP_LOGCONFIG(TAG, "  - connected sensor: %s", sensor->get_name().c_str());

--- a/components/bthome_receiver_base/bthome_receiver_base_device.h
+++ b/components/bthome_receiver_base/bthome_receiver_base_device.h
@@ -32,6 +32,9 @@ namespace esphome
       void set_dump_option(DumpOption_e value) { this->dump_option_ = value; };
       std::string get_name_prefix() { return name_prefix_; };
       void set_name_prefix(std::string value) { name_prefix_ = value; };
+      const uint8_t *get_encryption_key() { return encryption_key_set_ ? encryption_key_ : nullptr; };
+      bool has_encryption_key() { return encryption_key_set_; };
+      void set_encryption_key(const uint8_t *key);
 
       void dump_config() override;
       void report_measurements_(vector<bthome_base::bthome_measurement_record_t> measurements, measurement_log_handler_t measurement_log_handler_cb);
@@ -42,6 +45,8 @@ namespace esphome
       DumpOption_e dump_option_{DumpOption_None};
       bthome_base::mac_address_t address_{0};
       std::string name_prefix_{};
+      uint8_t encryption_key_[16];
+      bool encryption_key_set_{false};
 
       std::vector<BTHomeReceiverBaseBaseSensor *> my_sensors;
     };

--- a/components/docs/bthome_ble_receiver.rst
+++ b/components/docs/bthome_ble_receiver.rst
@@ -1,9 +1,9 @@
 ESP32 BTHome Receiver
 =====================
 
-**BTHome** is an energy efficient but flexible BLE (Bluetooth Low Energy) format for devices to 
+**BTHome** is an energy efficient but flexible BLE (Bluetooth Low Energy) format for devices to
 broadcast their sensor data and  button presses. Devices can run over a year on a single battery.
-It allows data encryption and is supported by popular home automation platforms, 
+It allows data encryption and is supported by popular home automation platforms,
 like `Home Assistant <https://www.home-assistant.io>`__, out of the box.
 
 This component implements local reception and decoding without the need of a central hub.
@@ -16,7 +16,7 @@ Encryption support might be implemented later on.
     # Example configuration entry
     external_components:
       - source: github://juleskers/esphome_component_bthome
-    
+
     esp32_ble_tracker:
 
     bthome_ble_receiver:
@@ -62,10 +62,10 @@ Component/Hub
 The ``bthome_ble_receiver`` component creates a global hub so that you can track bluetooth low
 energy devices using your ESP32 node over the BTHome protocol using both v1 and v2 protocols.
 
-The component depends on the ``esp32_ble_tracker`` component which needs to be added to the 
+The component depends on the ``esp32_ble_tracker`` component which needs to be added to the
 configuration.
 
-The bthome receiver component is an internal model that acts as a central reception 
+The bthome receiver component is an internal model that acts as a central reception
 and dispatcher hub to which bthome virtual devices and sensors are connected to.
 
 .. _config-bthome:
@@ -73,9 +73,9 @@ and dispatcher hub to which bthome virtual devices and sensors are connected to.
 Configuration variables:
 ************************
 
-- **dump** (*Optional*): Decode and dumpincoming remote readings codes in the logs 
+- **dump** (*Optional*): Decode and dumpincoming remote readings codes in the logs
   (at log.level=DEBUG) for any device.
-  
+
   - **all**: Decode and dump all readings.
   - **unmatched**: Decode and dump readings that are not mapped in configuration.
   - **none**: (default) Decode but do not dump any readings.
@@ -88,21 +88,22 @@ Configuration variables:
 
   - **name_prefix** (*Optional*): Device name to append before any sensor name as a prefix.
 
-  - **dump** (*Optional*): Decode and dump incoming remote readings codes in the logs 
+  - **dump** (*Optional*): Decode and dump incoming remote readings codes in the logs
     (at log.level=DEBUG) for this device.
 
+  - **encryption_key** (*Optional*): Encryption key for the device.
 
 .. _bthome-sensor:
 
 Sensor and Binary Sensor as *virtual device*
 --------------------------------------------
 
-The bthome sensor allows you use a sensor to display received measurement from a remote 
+The bthome sensor allows you use a sensor to display received measurement from a remote
 BTHome device.
 First, you need to define a :ref:`bthome hub component <bthome-component>`.
 
-The bthome sensor component (or "device") is an internal model that acts as a central reception 
-and dispatcher hub for a specific remote device identified by a ``mac_address`` to which bthome 
+The bthome sensor component (or "device") is an internal model that acts as a central reception
+and dispatcher hub for a specific remote device identified by a ``mac_address`` to which bthome
 sensors are connected to.
 
 To initialize a sensor, first supply ``mac_address`` to identify the remote BTHome device.
@@ -135,14 +136,14 @@ Configuration variables:
 - **mac_address** (**Required**, mac-address): The address of the sensor.
 
 - **sensors** (*Required*): List of remote sensor connected to this virtual device.
-  
+
   - **name** (*Optional*): The name for the sensor. At least one of **id** and **name** must be specified.
 
-  - **measurement_type** (*Required*, int **or** string): Measurement type as defined in 
-    `BTHome format specification <https://bthome.io/format>`__ either as a string or a numeric value. 
-    If selected by name (string) the accuracy and unit of measurement are automatically defaulted to the 
+  - **measurement_type** (*Required*, int **or** string): Measurement type as defined in
+    `BTHome format specification <https://bthome.io/format>`__ either as a string or a numeric value.
+    If selected by name (string) the accuracy and unit of measurement are automatically defaulted to the
     correct values.
-    
+
     Measurement type `further details <bthome_common_format.rst>`__ to be taken into account.
 
 See Also


### PR DESCRIPTION
This PR adds support for [BTHome Encryption](https://bthome.io/encryption/) and is based on the published spec.

It is currently still WIP, and has not (yet) had any real-world testing.